### PR TITLE
Fix matching of "select zz_utils.set_project_schema_owner_role(...)".

### DIFF
--- a/codevalidator.py
+++ b/codevalidator.py
@@ -605,8 +605,8 @@ def _validate_sql_diff_sql(fname, options=None):
     sql = open(fname).read()
     has_set_role = re.search('[Ss][Ee][Tt] +[Rr][Oo][Ll][Ee] +[Tt][Oo] +zalando(_admin)?\s*', sql)
     has_set_project_schema_owner_role = \
-        re.search('''^ *[Ss][Ee][Ll][Ee][Cc][Tt] +[Zz][Zz]_[Uu][Tt][Ii][Ll][Ss].[Ss][Ee][Tt]_[Pp][Rr][Oo][Jj][Ee][Cc][Tt]_[Ss][Cc][Hh][Ee][Mm][Aa]_[Oo][Ww][Nn][Ee][Rr]_[Rr][Oo][Ll][Ee]\(\'\w+\'\);'''
-                  , sql)
+        re.search('''^ *select zz_utils\.set_project_schema_owner_role\('\w+'\);'''
+                  , sql, re.MULTILINE + re.IGNORECASE)
     if not (has_set_role or has_set_project_schema_owner_role):
         return 'set role to zalando; or SELECT zz_utils.set_project_schema_owner_role(); must be present in db diff'
 


### PR DESCRIPTION
Up to now, it only matched at start of the file. Instead, match also at start of line.
Also, use case-insensitive matching instead of `[Ss][Ee][Ll][Ee][Cc][Tt]` style regexp.

See discussion in git@Zalando chat for some background.
