### PR TITLE
Py3

### DIFF
--- a/codevalidator.py
+++ b/codevalidator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -554,7 +554,7 @@ def _validate_pyflakes(fd, options={}):
 def _validate_database_dir(fname, options={}):
     if 'database/lounge' in fname or not fnmatch.fnmatch(fname, '*.sql'):
         return True
-    pgsqlparser_bin = options.get('pgsql-parser-bin', '/opt/codevalidator/PgSqlParser')
+    pgsqlparser_bin = options.get('pgsql-parser-bin', '/opt/codevalidator/PgSqlParserm')
     if not os.path.isfile(pgsqlparser_bin):
         raise ExecutionError('PostgreSQL parser binary not found, please set "pgsql-parser-bin" option')
 
@@ -837,7 +837,8 @@ def main():
         if os.path.isfile(config_file) and not args.config:
             args.config = config_file
     if args.config:
-        CONFIG.update(json.load(open(args.config, 'rb')))
+        config = open(args.config, 'rb').read().decode()
+        CONFIG.update(json.loads(config))
     if args.verbose:
         CONFIG['verbose'] = args.verbose
         if args.verbose > 1:

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -209,7 +209,7 @@ def _validate_ascii(fd):
 
 @message('has UTF-8 byte order mark (BOM)')
 def _validate_nobom(fd):
-    return not fd.read(3).startswith('\xef\xbb\xbf')
+    return not fd.read(3).startswith(b'\xef\xbb\xbf')
 
 
 @message('contains invalid indentation (not 4 spaces)')

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -300,7 +300,7 @@ def _validate_yaml(fd):
 
 @message('is not PythonTidy formatted')
 def _validate_pythontidy(fd):
-    if is_python3(fd) or sys.version_info.major == 3:
+    if is_python3(fd) or is_py3:
         # PythonTidy supports Python 2 only
         return True
     source = StringIO(fd.read())

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -245,7 +245,6 @@ def _validate_notrailingws(fd):
 
 def _fix_notrailingws(src, dst):
     for line in src:
-        line = line.decode() if is_py3 else line
         dst.write(line.rstrip())
         dst.write('\n')
 

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -173,19 +173,21 @@ def _validate_invalidpath(fd):
 
 @message('contains tabs')
 def _validate_notabs(fd):
-    return '\t' not in fd.read()
+    return b'\t' not in fd.read()
 
 
 def _fix_notabs(src, dst):
+    # TODO test this
     dst.write(src.read().replace('\t', ' ' * 4))
 
 
 @message('contains carriage return (CR)')
 def _validate_nocr(fd):
-    return '\r' not in fd.read()
+    return b'\r' not in fd.read()
 
 
 def _fix_nocr(src, dst):
+    # TODO test this
     dst.write(src.read().replace('\r', ''))
 
 
@@ -228,12 +230,13 @@ def _validate_indent4(fd):
 @message('contains lines with trailing whitespace')
 def _validate_notrailingws(fd):
     for line in fd:
-        if line.rstrip('\n\r')[-1:] in TRAILING_WHITESPACE_CHARS:
+        if line.rstrip(b'\n\r')[-1:] in TRAILING_WHITESPACE_CHARS:
             return False
     return True
 
 
 def _fix_notrailingws(src, dst):
+    # TODO test this
     for line in src:
         dst.write(line.rstrip())
         dst.write('\n')

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -36,7 +36,7 @@ if sys.version_info.major == 2:
     # Pythontidy is only supported on Python2
     from pythontidy import PythonTidy
 
-is_py3 = sys.version_info.major == 3
+running_on_py3 = sys.version_info.major == 3
 
 
 NOT_SPACE = re.compile('[^ ]')
@@ -237,7 +237,7 @@ def _validate_indent4(fd):
 @message('contains lines with trailing whitespace')
 def _validate_notrailingws(fd):
     for line in fd:
-        line = line.decode() if is_py3 else line
+        line = line.decode() if running_on_py3 else line
         if line.rstrip('\n\r')[-1:] in TRAILING_WHITESPACE_CHARS:
             return False
     return True
@@ -300,7 +300,7 @@ def _validate_yaml(fd):
 
 @message('is not PythonTidy formatted')
 def _validate_pythontidy(fd):
-    if is_python3(fd) or is_py3:
+    if is_python3(fd) or running_on_py3:
         # PythonTidy supports Python 2 only
         return True
     source = StringIO(fd.read())

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -560,7 +560,7 @@ def _validate_pyflakes(fd, options={}):
 def _validate_database_dir(fname, options={}):
     if 'database/lounge' in fname or not fnmatch.fnmatch(fname, '*.sql'):
         return True
-    pgsqlparser_bin = options.get('pgsql-parser-bin', '/opt/codevalidator/PgSqlParserm')
+    pgsqlparser_bin = options.get('pgsql-parser-bin', '/opt/codevalidator/PgSqlParser')
     if not os.path.isfile(pgsqlparser_bin):
         raise ExecutionError('PostgreSQL parser binary not found, please set "pgsql-parser-bin" option')
 

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -350,10 +350,10 @@ def __jalopy(original, options, use_nailgun=True):
             j = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=_env)
             stdout, stderr = j.communicate()
             if stderr or '[ERROR]' in stdout:
-                if stderr.strip() == 'connect: Connection refused':
+                if stderr.strip().decode() == 'connect: Connection refused':
                     # Fallback
                     return __jalopy(original, options, use_nailgun=False)
-                raise ExecutionError('Failed to execute Jalopy: %s%s' % (stderr, stdout))
+                raise ExecutionError('Failed to execute Jalopy: %s%s' % (stderr.decode(), stdout.decode()))
             if '[WARN]' in stdout:
                 logging.info('Jalopy reports warnings: %s', stdout)
             name = os.path.basename(f.name)

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -11,9 +11,9 @@ from __future__ import print_function
 
 try:
     from StringIO import StringIO
-except ImportError:
+except:
     # Python 3
-    from io import StringIO, BytesIO
+    from io import StringIO
 from collections import defaultdict
 
 from pythontidy import PythonTidy
@@ -292,8 +292,10 @@ def _validate_yaml(fd):
 
 @message('is not PythonTidy formatted')
 def _validate_pythontidy(fd):
-    # TODO test with python3
-    source = StringIO(fd.read().decode())
+    if is_python3(fd):
+        # PythonTidy supports Python 2 only
+        return True
+    source = StringIO(fd.read())
     if len(source.getvalue()) < 4:
         # small or empty files are ignored
         return True

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -11,12 +11,11 @@ from __future__ import print_function
 
 try:
     from StringIO import StringIO
-except:
+except ImportError:
     # Python 3
     from io import StringIO
 from collections import defaultdict
 
-from pythontidy import PythonTidy
 from tempfile import NamedTemporaryFile
 from xml.etree.ElementTree import ElementTree
 from xml.etree.ElementTree import fromstring as xmlfromstring
@@ -32,6 +31,11 @@ import subprocess
 import sys
 import tempfile
 import shutil
+
+if sys.version_info.major == 2:
+    # Pythontidy is only supported on Python2
+    from pythontidy import PythonTidy
+
 
 NOT_SPACE = re.compile('[^ ]')
 
@@ -292,7 +296,7 @@ def _validate_yaml(fd):
 
 @message('is not PythonTidy formatted')
 def _validate_pythontidy(fd):
-    if is_python3(fd):
+    if is_python3(fd) or sys.version_info.major == 3:
         # PythonTidy supports Python 2 only
         return True
     source = StringIO(fd.read())

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -11,9 +11,9 @@ from __future__ import print_function
 
 try:
     from StringIO import StringIO
-except:
+except ImportError:
     # Python 3
-    from io import StringIO
+    from io import StringIO, BytesIO
 from collections import defaultdict
 
 from pythontidy import PythonTidy
@@ -292,10 +292,8 @@ def _validate_yaml(fd):
 
 @message('is not PythonTidy formatted')
 def _validate_pythontidy(fd):
-    if is_python3(fd):
-        # PythonTidy supports Python 2 only
-        return True
-    source = StringIO(fd.read())
+    # TODO test with python3
+    source = StringIO(fd.read().decode())
     if len(source.getvalue()) < 4:
         # small or empty files are ignored
         return True

--- a/pythontidy/PythonTidy.py
+++ b/pythontidy/PythonTidy.py
@@ -637,10 +637,7 @@ class InputUnit(object):
         self.end = len(self.lines) - 1
         return self
 
-    def next(self):
-        return self.__next__()
-
-    def __next__(self):  # 2006 Dec 05
+    def next(self):  # 2006 Dec 05
         if self.ndx > self.end:
             raise StopIteration
         elif self.ndx == self.end:
@@ -655,7 +652,7 @@ class InputUnit(object):
 
     def readline(self):  # 2006 Dec 05
         try:
-            result = next(self)
+            result = self.next()
         except StopIteration:
             result = NULL
         return result
@@ -944,7 +941,7 @@ class Comments(dict):
 
             try:
                 while True:
-                    prev_item = next(lines)
+                    prev_item = lines.next()
                     yield prev_item
 
                     (
@@ -957,7 +954,7 @@ class Comments(dict):
                     if prev_token_type in [tokenize.STRING]:
                         on1 = True
                         while True:
-                            next_item = next(lines)
+                            next_item = lines.next()
                             yield next_item
 
                             (
@@ -1004,8 +1001,7 @@ class Comments(dict):
             erow, ecol = end
             if token_type in [tokenize.COMMENT, tokenize.NL]:
                 original = token_string
-                if not is_py3:
-                    original = original.decode(INPUT.coding)
+                original = original.decode(INPUT.coding)
                 original = original.replace('\t', DOC_TAB_REPLACEMENT)  # 2007 May 24
                 original = original.strip()
                 if SHEBANG_PATTERN.match(original) is not None:
@@ -4235,8 +4231,7 @@ class NodeTryExcept(Node):
                 if target is None:
                     pass
                 else:
-                    separator = 'as ' if is_py3 else LIST_SEP
-                    self.line_more(separator, can_break_after=True)
+                    self.line_more(LIST_SEP, can_break_after=True)
                     target.put()
             self.line_more(':')
             self.line_term(suite.get_lineno() - 1)
@@ -4570,12 +4565,6 @@ def tidy_up(file_in=sys.stdin, file_out=sys.stdout):  # 2007 Jan 22
     OUTPUT = OutputUnit(file_out)
     COMMENTS = Comments()
     NAME_SPACE = NameSpace()
-    input_is_python3 = str(INPUT).startswith('#!/usr/bin/env python3')
-    if input_is_python3 != is_py3:
-        file_in.seek(0)
-        file_out.write(file_in.read())
-        return
-        # we can't validate different python versions
     module = ast.parse(str(INPUT)) if is_py3 else compiler.parse(str(INPUT))
     module = transform(indent=ZERO, lineno=ZERO, node=module)
     INPUT_CODING = INPUT.coding  # 2007 May 23

--- a/pythontidy/PythonTidy.py
+++ b/pythontidy/PythonTidy.py
@@ -637,7 +637,10 @@ class InputUnit(object):
         self.end = len(self.lines) - 1
         return self
 
-    def next(self):  # 2006 Dec 05
+    def next(self):
+        return self.__next__()
+
+    def __next__(self):  # 2006 Dec 05
         if self.ndx > self.end:
             raise StopIteration
         elif self.ndx == self.end:
@@ -652,7 +655,7 @@ class InputUnit(object):
 
     def readline(self):  # 2006 Dec 05
         try:
-            result = self.next()
+            result = next(self)
         except StopIteration:
             result = NULL
         return result
@@ -941,7 +944,7 @@ class Comments(dict):
 
             try:
                 while True:
-                    prev_item = lines.next()
+                    prev_item = next(lines)
                     yield prev_item
 
                     (
@@ -954,7 +957,7 @@ class Comments(dict):
                     if prev_token_type in [tokenize.STRING]:
                         on1 = True
                         while True:
-                            next_item = lines.next()
+                            next_item = next(lines)
                             yield next_item
 
                             (
@@ -1001,7 +1004,8 @@ class Comments(dict):
             erow, ecol = end
             if token_type in [tokenize.COMMENT, tokenize.NL]:
                 original = token_string
-                original = original.decode(INPUT.coding)
+                if not is_py3:
+                    original = original.decode(INPUT.coding)
                 original = original.replace('\t', DOC_TAB_REPLACEMENT)  # 2007 May 24
                 original = original.strip()
                 if SHEBANG_PATTERN.match(original) is not None:
@@ -4231,7 +4235,8 @@ class NodeTryExcept(Node):
                 if target is None:
                     pass
                 else:
-                    self.line_more(LIST_SEP, can_break_after=True)
+                    separator = 'as ' if is_py3 else LIST_SEP
+                    self.line_more(separator, can_break_after=True)
                     target.put()
             self.line_more(':')
             self.line_term(suite.get_lineno() - 1)
@@ -4565,6 +4570,12 @@ def tidy_up(file_in=sys.stdin, file_out=sys.stdout):  # 2007 Jan 22
     OUTPUT = OutputUnit(file_out)
     COMMENTS = Comments()
     NAME_SPACE = NameSpace()
+    input_is_python3 = str(INPUT).startswith('#!/usr/bin/env python3')
+    if input_is_python3 != is_py3:
+        file_in.seek(0)
+        file_out.write(file_in.read())
+        return
+        # we can't validate different python versions
     module = ast.parse(str(INPUT)) if is_py3 else compiler.parse(str(INPUT))
     module = transform(indent=ZERO, lineno=ZERO, node=module)
     INPUT_CODING = INPUT.coding  # 2007 May 23

--- a/pythontidy/PythonTidy.py
+++ b/pythontidy/PythonTidy.py
@@ -297,13 +297,7 @@ if DEBUG:
     import token
     import doctest
 import tokenize
-
-is_py3 = sys.version_info.major == 3
-
-if is_py3:
-    import ast
-else:
-    import compiler
+import compiler
 
 ZERO = 0
 SPACE = ' '
@@ -4565,7 +4559,7 @@ def tidy_up(file_in=sys.stdin, file_out=sys.stdout):  # 2007 Jan 22
     OUTPUT = OutputUnit(file_out)
     COMMENTS = Comments()
     NAME_SPACE = NameSpace()
-    module = ast.parse(str(INPUT)) if is_py3 else compiler.parse(str(INPUT))
+    module = compiler.parse(str(INPUT))
     module = transform(indent=ZERO, lineno=ZERO, node=module)
     INPUT_CODING = INPUT.coding  # 2007 May 23
     del INPUT

--- a/pythontidy/PythonTidy.py
+++ b/pythontidy/PythonTidy.py
@@ -297,7 +297,13 @@ if DEBUG:
     import token
     import doctest
 import tokenize
-import compiler
+
+is_py3 = sys.version_info.major == 3
+
+if is_py3:
+    import ast
+else:
+    import compiler
 
 ZERO = 0
 SPACE = ' '
@@ -4559,7 +4565,7 @@ def tidy_up(file_in=sys.stdin, file_out=sys.stdout):  # 2007 Jan 22
     OUTPUT = OutputUnit(file_out)
     COMMENTS = Comments()
     NAME_SPACE = NameSpace()
-    module = compiler.parse(str(INPUT))
+    module = ast.parse(str(INPUT)) if is_py3 else compiler.parse(str(INPUT))
     module = transform(indent=ZERO, lineno=ZERO, node=module)
     INPUT_CODING = INPUT.coding  # 2007 May 23
     del INPUT


### PR DESCRIPTION
Fixes to support Python3. I disabled pythontidy completely in python3 because fixing all the possible syntax problems and supporting both Python 2 and Python 3 would need a large rewrite.