### PR TITLE
Use yaml.BaseLoader to avoid parsing tags

### DIFF
--- a/codevalidator.py
+++ b/codevalidator.py
@@ -286,7 +286,7 @@ def _validate_yaml(fd):
         # Using BaseLoader because it doesn't parse tags
         loader = yaml.BaseLoader(fd)
         while loader.check_data():
-            print(loader.get_data())
+            loader.get_data()
     except Exception as e:
         _detail('%s: %s' % (e.__class__.__name__, e))
         return False

--- a/codevalidator.py
+++ b/codevalidator.py
@@ -283,7 +283,10 @@ def _validate_json(fd):
 def _validate_yaml(fd):
     import yaml
     try:
-        list(yaml.safe_load_all(fd))
+        # Using BaseLoader because it doesn't parse tags
+        loader = yaml.BaseLoader(fd)
+        while loader.check_data():
+            print(loader.get_data())
     except Exception as e:
         _detail('%s: %s' % (e.__class__.__name__, e))
         return False


### PR DESCRIPTION
Codevalidator is currently failing for yaml files with serialized java objects because it's trying to parse the tags.