### PR TITLE
Support recursive yaml nodes

### DIFF
--- a/codevalidator.py
+++ b/codevalidator.py
@@ -283,8 +283,10 @@ def _validate_json(fd):
 def _validate_yaml(fd):
     import yaml
     try:
-        # Using BaseLoader because it doesn't parse tags
-        loader = yaml.BaseLoader(fd)
+        # Using safeloader because it supports recursive nodes
+        loader = yaml.SafeLoader(fd)
+        # Support random tags
+        loader.add_multi_constructor('!', (lambda _, tag, _2: tag)) 
         while loader.check_data():
             loader.get_data()
     except Exception as e:


### PR DESCRIPTION
SafeLoader supports recursive nodes while BaseLoader doesn't. To support "unkown" tags we just need to add a constructor for everything that starts with !